### PR TITLE
showing code next to name for clearity

### DIFF
--- a/src/components/Collection/collection.actions.js
+++ b/src/components/Collection/collection.actions.js
@@ -175,7 +175,7 @@ class CollectionActions extends React.Component {
       okText: mergeLabel,
       okType: 'primary',
       cancelText: cancelLabel,
-      content: <div>
+      content: <div style={{ paddingRight: '12px' }}> 
         <CollectionSuggest user={user} intl={intl} hiddenEntries={[this?.props?.collection?.key]} value={this.state.mergeWithCollection} onChange={collection => this.setState({ mergeWithCollection: collection })} style={{ width: '100%' }} />
         <div style={{ marginTop: 10, color: '#888' }}>
           {description}

--- a/src/components/Institution/institution.actions.js
+++ b/src/components/Institution/institution.actions.js
@@ -191,7 +191,7 @@ class InstitutionActions extends React.Component {
       okText: mergeLabel,
       okType: 'primary',
       cancelText: cancelLabel,
-      content: <div>
+      content: <div style={{ paddingRight: '12px' }}> 
         <InstitutionSuggest hiddenEntries={[this?.props?.institution?.key]} user={user} intl={intl} value={this.state.mergeWithInstitution} onChange={institution => this.setState({ mergeWithInstitution: institution })} style={{ width: '100%' }} />
         <div style={{ marginTop: 10, color: '#888' }}>
           {description}

--- a/src/components/common/suggest/Suggest.js
+++ b/src/components/common/suggest/Suggest.js
@@ -116,7 +116,12 @@ class Suggest extends React.Component {
         >
           {items && items.map(item => (
             <Select.Option value={item.key} key={item.key}>
-              {item[titleField]}
+              <div style={{ display: 'flex', justifyContent: 'space-between', whiteSpace: 'nowrap', overflow: 'hidden', width: '100%' }}>
+                <span style={{ textOverflow: 'ellipsis', overflow: 'hidden', flex: '1 1 100%', marginRight: '5px' }}>
+                  {item[titleField]}
+                </span>
+                <small style={{ whiteSpace: 'nowrap', flex: '0 0 auto' }}>{item.code}</small>
+              </div>
             </Select.Option>
           ))}
         </Select>


### PR DESCRIPTION
https://github.com/gbif/registry/issues/652

Related changes for this bug. I have added the codes to make things more clear for the user but select components size is changing with the length of the name. It's not overflowing now but it still changes with name. 